### PR TITLE
検索結果の食材チップ個数を「食材ごとの最大数」表示に変更、料理を3行表示に調整

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -166,8 +166,8 @@ main {
 
 .result-card .dishes {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
   margin-bottom: 8px;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -140,11 +140,11 @@
     return set;
   }
 
-  function totalQuantities(dishes) {
+  function maxQuantities(dishes) {
     const counts = {};
     for (const dish of dishes) {
       for (const ing of dish.ingredients) {
-        counts[ing.name] = (counts[ing.name] || 0) + ing.count;
+        counts[ing.name] = Math.max(counts[ing.name] || 0, ing.count);
       }
     }
     return counts;
@@ -175,7 +175,7 @@
             dishes,
             union,
             unionSize: union.size,
-            quantities: totalQuantities(dishes.map((d) => d.recipe))
+            quantities: maxQuantities(dishes.map((d) => d.recipe))
           });
         }
       }


### PR DESCRIPTION
# 概要
検索結果カードの改善2点。
# 変更内容
- 食材チップの個数表示を「全食事の食材個数の合計」→「最大値」に変更
- js/app.js: totalQuantities（和集計）を maxQuantities（最大値集計）に置き換え
- 例: ミルク×10・×5の料理を使う組み合わせは、これまで「×15」→ 今回「×10」表示
- カレー／デザート／サラダの表示を横並び→3行（縦並び）に変更
- css/style.css: .result-card .dishes を flex-wrap から flex-direction: column に変更
# 動作確認
- 最大食材7種・ratio1.1 の検索で 3,937 件
- 先頭カード「満腹チーズバーグカレー / じゅくせいスイートポテト / ゆきかきシーザーサラダ」のチップが
ほっこりポテト×9・マメミート×8・モーモーミルク×10 となり、max集計（合計より小さい値）と一致
- 全500カードで各カード3行（3料理）表示を確認