### PR TITLE
最低エナジーでの絞り込みを追加(チェックボックス切替)、デフォルト値を調整

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,23 @@ main {
   width: 140px;
 }
 
+.field input[type="number"]:disabled {
+  background: #f0efea;
+  color: #aaa;
+}
+
+.field .toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text);
+  padding-top: 22px;
+  white-space: nowrap;
+}
+
 .fields {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/index.html
+++ b/index.html
@@ -17,11 +17,21 @@
       <div class="controls">
         <div class="field">
           <label for="max-types">食材種類数 (上限)</label>
-          <input type="number" id="max-types" min="1" max="20" value="5">
+          <input type="number" id="max-types" min="1" max="20" value="6">
         </div>
         <div class="field">
           <label for="min-ratio">最低 ratio (各料理)</label>
-          <input type="number" id="min-ratio" min="0" step="0.01" value="1.3">
+          <input type="number" id="min-ratio" min="0" step="0.01" value="1.25">
+        </div>
+        <div class="field">
+          <label for="min-energy">最低エナジー (各料理)</label>
+          <input type="number" id="min-energy" min="0" step="100" value="8000" disabled>
+        </div>
+        <div class="field">
+          <label class="toggle">
+            <input type="checkbox" id="filter-energy">
+            最低エナジーで絞り込む
+          </label>
         </div>
       </div>
       <div class="fields">
@@ -37,7 +47,7 @@
         </div>
       </div>
       <div class="actions">
-        <button type="button" id="search" class="primary-btn">検索</button>
+        <button type="button" id="search" class="primary-btn" disabled>検索</button>
       </div>
     </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -43,6 +43,8 @@
   const els = {
     maxTypes: $("max-types"),
     minRatio: $("min-ratio"),
+    minEnergy: $("min-energy"),
+    filterEnergy: $("filter-energy"),
     ngList: $("ng-list"),
     ngClear: $("ng-clear"),
     hlList: $("hl-list"),
@@ -152,7 +154,9 @@
 
   function search() {
     const maxTypes = parseInt(els.maxTypes.value, 10) || Infinity;
-    const minRatio = parseFloat(els.minRatio.value) || 0;
+    const useEnergy = els.filterEnergy.checked;
+    const minRatio = useEnergy ? 0 : parseFloat(els.minRatio.value) || 0;
+    const minEnergy = useEnergy ? parseInt(els.minEnergy.value, 10) || 0 : 0;
 
     const candidates = [];
     for (const key of Object.keys(state.categories)) {
@@ -170,7 +174,11 @@
           }
           const union = unionOf(dishes.map((d) => d.recipe));
           if (union.size > maxTypes) continue;
-          if (dishes.some(({ recipe }) => recipe.ratio < minRatio)) continue;
+          if (useEnergy) {
+            if (dishes.some(({ recipe }) => recipe.initialEnergy < minEnergy)) continue;
+          } else if (dishes.some(({ recipe }) => recipe.ratio < minRatio)) {
+            continue;
+          }
           hits.push({
             dishes,
             union,
@@ -240,6 +248,12 @@
   }
 
   els.search.addEventListener("click", search);
+
+els.filterEnergy.addEventListener("change", () => {
+  const useEnergy = els.filterEnergy.checked;
+  els.minRatio.disabled = useEnergy;
+  els.minEnergy.disabled = !useEnergy;
+});
 
   loadData().catch((err) => {
     els.results.innerHTML = '<div class="loading">データの読み込みに失敗しました: ' + err.message + "</div>";


### PR DESCRIPTION
# 概要
検索条件のフィルタを「最低ratio」だけでなく「最低エナジー」でも指定できるようにしました。チェックボックスで切り替えます。
# 変更内容
- エナジーフィルタ追加: チェックボックス「最低エナジーで絞り込む」を追加
- チェック入れると有効な入力欄が「最低エナジー（各料理）」に切り替わり、全料理の初期エナジーが指定値以上の組み合わせのみを表示
- ratio入力は自動で無効化（reverseも同様）
- js/app.js: フィルタ判定を recipe.ratio / recipe.initialEnergy で切替（search()）
- 入力欄・切替UI: 最低エナジー入力欄とトグルを追加、非選択側の入力欄は disabled でグレー表示
- index.html / css/style.css
- デフォルト値変更: 食材種類数 5→6、最低ratio 1.3→1.25、エナジーは 8000（初期値）
- 検索ボタン: データ読み込み完了まで disabled（読込前クリック時のエラー防止）
# 動作確認
- ratioモード: 6種・ratio1.3 → 8件（従来動作と同一）
- エナジーモード（20種・20000）: 18件、全カードの全料理がエナジー 20,000以上
- トグル切替で入力欄の有効/無効が切り替わることを確認