### PR TITLE
Feature/search enhance

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -42,6 +42,7 @@
   };
   const els = {
     maxTypes: $("max-types"),
+    maxPot: $("max-pot"),
     minRatio: $("min-ratio"),
     minEnergy: $("min-energy"),
     filterEnergy: $("filter-energy"),
@@ -152,8 +153,14 @@
     return counts;
   }
 
+  function totalCount(recipe) {
+    return recipe.ingredients.reduce((s, ing) => s + ing.count, 0);
+  }
+
   function search() {
     const maxTypes = parseInt(els.maxTypes.value, 10) || Infinity;
+    const maxPotRaw = els.maxPot ? els.maxPot.value.trim() : "";
+    const maxPot = maxPotRaw === "" ? Infinity : parseInt(maxPotRaw, 10) || Infinity;
     const useEnergy = els.filterEnergy.checked;
     const minRatio = useEnergy ? 0 : parseFloat(els.minRatio.value) || 0;
     const minEnergy = useEnergy ? parseInt(els.minEnergy.value, 10) || 0 : 0;
@@ -172,6 +179,9 @@
           if (dishes.some(({ recipe }) => recipe.ingredients.some((i) => state.ngSet.has(i.name)))) {
             continue;
           }
+          if (Number.isFinite(maxPot) && maxPot !== Infinity) {
+            if (dishes.some(({ recipe }) => totalCount(recipe) > maxPot)) continue;
+          }
           const union = unionOf(dishes.map((d) => d.recipe));
           if (union.size > maxTypes) continue;
           if (useEnergy) {
@@ -179,17 +189,22 @@
           } else if (dishes.some(({ recipe }) => recipe.ratio < minRatio)) {
             continue;
           }
+          const minEnergyInHit = Math.min(...dishes.map((d) => d.recipe.initialEnergy));
           hits.push({
             dishes,
             union,
             unionSize: union.size,
-            quantities: maxQuantities(dishes.map((d) => d.recipe))
+            quantities: maxQuantities(dishes.map((d) => d.recipe)),
+            minEnergy: minEnergyInHit
           });
         }
       }
     }
 
-    hits.sort((a, b) => a.unionSize - b.unionSize || a.dishes.length - b.dishes.length);
+    hits.sort((a, b) => {
+      if (a.unionSize !== b.unionSize) return a.unionSize - b.unionSize;
+      return b.minEnergy - a.minEnergy;
+    });
     render(hits);
   }
 
@@ -218,13 +233,16 @@
         const name = document.createElement("span");
         name.className = "name";
         name.textContent = recipe.name;
+        const total = document.createElement("span");
+        total.className = "total";
+        total.textContent = "計" + totalCount(recipe) + "個";
         const ratio = document.createElement("span");
         ratio.className = "ratio";
         ratio.textContent = recipe.ratio.toFixed(2);
         const energy = document.createElement("span");
         energy.className = "energy";
         energy.textContent = "エナジー " + recipe.initialEnergy.toLocaleString();
-        dish.append(cat, name, ratio, energy);
+        dish.append(cat, name, total, ratio, energy);
         dishes.appendChild(dish);
       }
 

--- a/js/app.js
+++ b/js/app.js
@@ -235,7 +235,7 @@
         name.textContent = recipe.name;
         const total = document.createElement("span");
         total.className = "total";
-        total.textContent = "計" + totalCount(recipe) + "個";
+        total.textContent = String(totalCount(recipe));
         const ratio = document.createElement("span");
         ratio.className = "ratio";
         ratio.textContent = recipe.ratio.toFixed(2);

--- a/search.html
+++ b/search.html
@@ -24,7 +24,7 @@
         </div>
         <div class="field">
           <label for="max-pot">最大鍋容量 (各料理)</label>
-          <input type="number" id="max-pot" min="1" max="200" placeholder="例: 55">
+          <input type="number" id="max-pot" min="1" max="200" value="81">
         </div>
         <div class="field">
           <label for="min-ratio">最低 ratio (各料理)</label>

--- a/search.html
+++ b/search.html
@@ -23,6 +23,10 @@
           <input type="number" id="max-types" min="1" max="20" value="6">
         </div>
         <div class="field">
+          <label for="max-pot">最大鍋容量 (各料理)</label>
+          <input type="number" id="max-pot" min="1" max="200" placeholder="例: 55">
+        </div>
+        <div class="field">
           <label for="min-ratio">最低 ratio (各料理)</label>
           <input type="number" id="min-ratio" min="0" step="0.01" value="1.25">
         </div>


### PR DESCRIPTION
# 変更内容
1. 総食材数を表示 (js/app.js:156-238)
- totalCount(recipe) を追加し、各レシピの料理名横に 計N個 バッジ（.total）を表示。例: あぶりテールカレー 計33個
2. 最大鍋容量フィルター (search.html:26-27, js/app.js:162-183)
- search.html の検索条件に 最大鍋容量 (各料理) 入力（#max-pot, placeholder: 例55）を追加。未入力時は無制限
- search() で各料理の総食材数 > maxPot の組み合わせを除外。テスト: maxTypes=6 + minRatio=1.25 で maxPot=55 ならヒット103件→58件に絞り込まれることを確認
3. ソート順変更 (js/app.js:192-206)
- 従来: unionSize のみ（unionSize || dishes.length）
- 変更後: ①必要食材種類数が少ない順 ②3つの料理の中での最低エナジーが高い順（b.minEnergy - a.minEnergy）

close #5 