### PR TITLE
opencode公式ワークアラウンドを完全適用

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -22,19 +22,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Configure Git Identity
         run: |
           git config --global user.name "MuseSpark1.2"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Workaround for https://github.com/anomalyco/opencode/issues/16515
+          # and https://github.com/anomalyco/opencode/issues/37823
+          # TODO: Remove http.extraheader, TOKEN and use_github_token after
+          #       opencode > 1.18.21 with PR #37889 is deployed to api.opencode.ai
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64 -w0)"
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/muse-spark-1.2-contributor-free
           use_github_token: "true"


### PR DESCRIPTION
# 変更内容
- fetch-depth を 1 → 0 に変更（shallow clone での git config --local 取得失敗を回避。#16515）
- TOKEN 環境変数に修正（GITHUB_TOKEN では useEnvGithubToken() が参照せず OIDC 経路で p.rest。再現済み。#37823）
- http.extraheader を手動で設定（persist-credentials: false でも push 時に認証ヘッダを確実に付与。could not read Username 対策）
- 既存の MuseSpark1.2 の git config に加え、Issue #37823/#16515 へのリンクと TODO コメントを追加し、修正リリース後にワークアラウンドを削除できるように文書化

## 公式ワークアラウンドの適用と将来の戻し方について

本PRでは opencode 側の既知のバグ2件に対する公式ワークアラウンドを適用しています。

### 1. `Failed to parse JSON → p.rest` (OIDC)

- **upstream Issue**: https://github.com/anomalyco/opencode/issues/37823
  - 2026-07-15以降に作成されたリポジトリで GitHub の OIDC `sub` が `repo:owner@id/repo@id:ref:...` 形式に変わったため、`api.opencode.ai/exchange_github_app_token` が `owner@id/repo@id` をパースできず 500 → クライアントが `Failed to parse JSON` → `octoRest`未初期化で `p.rest`
- **本PRでのワークアラウンド**:
  ```yaml
  env: {TOKEN: ${{ secrets.GITHUB_TOKEN }}}
  with: {use_github_token: "true"}
  ```
  OIDC 交換を迂回し GITHUB_TOKEN を直接使う。fetch-depth: 0 と http.extraheader は直接関係しないが、後述の #16515 対策として併せて適用。
- 修正PR (upstream):
  - https://github.com/anomalyco/opencode/pull/37889 fix: handle GitHub OIDC format and error handling (Closes #37823) — 現在 OPEN
  - https://github.com/anomalyco/opencode/pull/40365 fix(github): support immutable OIDC subjects — 同上、別アプローチで OPEN
- 戻せる条件:
  - 上記いずれかが マージ され、*api.opencode.ai にデプロイ* された後（opencode の最新リリースが > 1.18.21 かつ Issue #37823 が Closed になったことを確認）。
  - 確認方法: https://github.com/anomalyco/opencode/releases で最新 tag が 1.18.22 以降かつ #37889/#40365 が含まれているか、または一時的に本PRの TOKEN/use_github_token を外して Issue で /oc hello が成功するかで検証。
  - 戻し方:
    ```yaml
    - TOKEN: ${{ secrets.GITHUB_TOKEN }}
    + GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # または env自体を削除し OIDC に戻す
    - use_github_token: "true"
    + # use_github_token を削除 (デフォルト false) → コミットが opencode-agent[bot] に戻る
    ```
TOKEN → GITHUB_TOKEN へのリネームだけでも動作するが、完全に App 表示に戻すなら use_github_token 行ごと削除。
2. Author identity unknown → could not read Username
- upstream Issue: https://github.com/anomalyco/opencode/issues/16515 github integration fails
  - persist-credentials: false + fetch-depth: 1 で configureGit() の git config --local --get http.extraheader が shallow clone で失敗 → http.extraheader 未設定 → git push が Username を対話的に要求して No such device
  - 同Issueは 60日経過で closed 扱いだが、コード側の根本修正は未リリース。ドキュメント修正は https://github.com/anomalyco/opencode/pull/9120 docs: add use_github_token で対応済み。
- 本PRでのワークアラウンド:
    ```
    fetch-depth: 0
    git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64 -w0)"
    git config --global user.name "MuseSpark1.2"  # ユーザー要望のモデル名
- 戻せる条件:
  - opencode の packages/opencode/src/cli/cmd/github.handler.ts の configureGit() が shallow clone (fetch-depth: 1) でも --local 取得失敗を無視して --global にフォールバックする修正がリリースされた場合。
  - 現時点で該当する Open PR はなし。Issue #16515 は closed だが、コード修正は未提供のため、当面は本ワークアラウンドを維持推奨。
  - 戻し方（将来修正された場合）:
    ```
    - fetch-depth: 0
    + fetch-depth: 1
    - git config --global http.https://github.com/.extraheader "..."
     # この1行を削除
      # user.name "MuseSpark1.2" はユーザー要望のため維持
    ```

### まとめ

| 本PRの変更 | 対応する upstream | 戻せる条件 | 戻し方 |
|---|---|---|---|
| `TOKEN` + `use_github_token: true` | #37823 → PR #37889 / #40365 | いずれかがマージ & `api.opencode.ai` にデプロイ後 (release > 1.18.21, Issue Closed) | `TOKEN` を削除し `use_github_token` 行を削除 → `opencode-agent[bot]` に戻る |
| `fetch-depth: 0` + `http.extraheader` | #16515 (修正PRなし) | `configureGit` が shallow clone に対応した修正がリリースされた場合 | `fetch-depth: 0` → `1` に戻し `http.extraheader` の1行を削除 |
| `user.name "MuseSpark1.2"` | ユーザー要望 | 恒久的に維持 | 戻さない |