### PR TITLE
opencode actionをstable v1.18.21にピン留め

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,7 +38,7 @@ jobs:
           git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64 -w0)"
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@v1.18.21
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Get opencode version での curl レートリミット (Issue #32635) を回避
- latest は毎回 api.github.com への未認証リクエストで 60 req/h 制限に引っかかりやすい
- v1.18.21 は cca4aad で動作確認済みの安定版。キャッシュヒットで Install がスキップされるためレートリミット影響を回避
- 上流で #32635 が修正され v1.19.x がリリースされたら latest に戻すか v1.19.x に上げる