### PR TITLE
opencodeワークフローにセキュリティ強化を追加

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,16 +8,19 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      (contains(github.event.comment.body, ' /oc') ||
+       startsWith(github.event.comment.body, '/oc') ||
+       contains(github.event.comment.body, ' /opencode') ||
+       startsWith(github.event.comment.body, '/opencode')) &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
       pull-requests: write
       issues: write
+      workflows: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
# 変更点
- permissions に workflows: write を追加（gh-pages PRプレビューで .github/workflows/deploy.yml を push する際に contents: write だけでは refusing to allow a GitHub App to create or update workflow で拒否されるため）
- if 条件に author_association == 'OWNER' || 'COLLABORATOR' を追加（第三者が /oc で悪意あるワークフローを作成するのを防止。PRを通さなければ main は汚染されないが、PRブランチの pull_request ワークフローが実行される余地があるため、トリガー自体を制限）