### PR TITLE
opencodeのexternal_directory権限を許可

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "/tmp/*": "allow"
+    }
+  }
+}


### PR DESCRIPTION
# 変更点:
- opencode.json を新規作成し、permission.external_directory."/tmp/*": "allow" を設定
- GitHub Actions 上で /tmp/* へのアクセスが ask で止まるのを解消
- 回帰テストで /tmp/opencode/site* へのコピーと MutationObserver での検証が Actions でも自動で実行可能に